### PR TITLE
chore: bump nolte/gh-plumbing pin from v1.1.12 to v1.1.18

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   automerge:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -3,16 +3,16 @@ on:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.18
 
   security:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.18
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
 
   chain-bench:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-cd-deliver-docs.yml
+++ b/.github/workflows/release-cd-deliver-docs.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish_docs:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   refresh_presentation_branch:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update_release_draft:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@v1.1.18
     permissions:
       # write permission is required to create a github release
       contents: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish_release:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   spelling:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@v1.1.18


### PR DESCRIPTION
## Summary

Bump every reusable-workflow pin in `.github/workflows/` from
`nolte/gh-plumbing@v1.1.12` to `@v1.1.18` so that PRs squash-merge
correctly and the merged source branch is deleted automatically.

## Changes

- automerge.yaml: `reusable-automerge.yaml@v1.1.12` → `@v1.1.18`
- spelling.yaml: `reusable-spelling-vale.yaml@v1.1.12` → `@v1.1.18`
- release-drafter.yml: `reusable-release-drafter.yml@v1.1.12` → `@v1.1.18`
- release-publish.yml: `reusable-release-publish.yml@v1.1.12` → `@v1.1.18`
- release-cd-refresh-master.yml: `reusable-release-cd-refresh-master.yml@v1.1.12` → `@v1.1.18`
- release-cd-deliver-docs.yml: `reusable-mkdocs.yaml@v1.1.12` → `@v1.1.18`
- build-static-tests.yaml: `reusable-pre-commit.yaml`, `reusable-trivy.yaml`, `reusable-chain-bench.yaml` all `@v1.1.12` → `@v1.1.18`

## Linked issues

Refs nolte/gh-plumbing#345 (closed) — the original report assumed the
override was missing upstream; it was already in place since v1.1.13
(MERGE_METHOD: squash, gh-plumbing#323) and v1.1.16 (MERGE_DELETE_BRANCH,
gh-plumbing#332). The actual fix for this repo is the pin bump.

Refs #21 — the PR that landed as a merge commit because of the stale
pin. No retroactive fix; the next PR using `automerge.yaml@v1.1.18`
will squash-merge as the spec requires.

## Testing

- `grep -rn "@v1\." .github/workflows/` confirms every reference now
  points to `@v1.1.18` and no `@v1.1.12` reference remains.
- `pre-commit run --all-files` — passes (check-yaml,
  end-of-file-fixer, trailing-whitespace).

## Risk / rollout notes

Low risk per release behaviour, but **this PR is itself the first
real test of `automerge.yaml@v1.1.18` in this repo**: a successful
squash-merge of this PR (single parent commit on develop instead of a
merge commit) confirms the bump fixed the symptom from #21. If this PR
also lands as a merge commit, open `workflow-health` triage against
`nolte/gh-plumbing` again with the run-log excerpt.

No source-include changes; no API-shape changes. Consumer repos that
fetch `taskfile-include-*.yaml` from this repository are not affected.