### PR TITLE
fix: add workflow_dispatch trigger to release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,10 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - develop
+  # Manual fallback when push-triggered runs miss commits — for example
+  # because an automerge action used GITHUB_TOKEN, which doesn't fire
+  # downstream workflows.
+  workflow_dispatch:
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## Summary

Add a `workflow_dispatch` trigger to `.github/workflows/release-drafter.yml`
so the draft release can be refreshed manually when the standard `push` trigger
gets skipped. Today, every merge that lands via `automerge.yaml` uses the
default `GITHUB_TOKEN`, and GitHub doesn't fire downstream workflows from a
token-driven push — so `release-drafter` hasn't run since 2026-04-22 even
though PRs #21, #22, and #23 have since merged to `develop`.

## Changes

- Add `workflow_dispatch:` to the `on:` block of `release-drafter.yml`.
- Inline a short comment explaining the manual-fallback motivation
  (token-driven pushes don't trigger downstream workflows).

## Linked issues

None

## Testing

- `pre-commit run --files .github/workflows/release-drafter.yml`: passed.
- Post-merge plan: `gh workflow run release-drafter.yml --ref develop`
  to refresh the open draft `v0.1.4` so it picks up PRs #21–#23, then resume
  `release-notes-curate`.

## Risk / rollout notes

Low risk — adds a manual trigger to an existing workflow. The `push` trigger
stays the default path; `workflow_dispatch` is the documented manual fallback.
The root cause (`GITHUB_TOKEN` not firing downstream workflows from the
automerge action) is a separate upstream fix in `nolte/gh-plumbing` and is
out of scope for this PR.