### PR TITLE
fix: forward tag + dry_run inputs to reusable release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,10 +3,28 @@ name: Release Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: |
+          Tag to publish. Must match an open release-drafter draft on the
+          repository's default branch. No "newest wins" heuristic per
+          spec/project/release-automation/ §Operational contract.
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          When true, run every validation gate but skip the final
+          `gh release edit --draft=false` call.
 
 jobs:
   publish_release:
     uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18
+    with:
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ inputs.dry_run }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:


### PR DESCRIPTION
## Summary

`.github/workflows/release-publish.yml` accepted no inputs on
`workflow_dispatch` and called the reusable workflow without a `with:`
block. Since `reusable-release-publish.yml@v1.1.18` declares `tag` as
`required: true`, every `gh workflow run release-publish.yml -f tag=<tag>`
would fail before any validation gate runs. This blocks the
`release-publish-trigger` skill flow and the operator-driven publish path
of `spec/project/release-automation/`.

## Changes

- Declare `tag` (required, string) and `dry_run` (optional boolean,
  default false) on the wrapper's `workflow_dispatch` block.
- Forward both inputs via `with:` to
  `reusable-release-publish.yml@v1.1.18`.
- Inline descriptions mirror the reusable-workflow contract verbatim so
  the dispatch UI on GitHub matches the spec language.

## Linked issues

Refs spec/project/release-automation/
Refs spec/project/release-skill-layer/

## Testing

- `pre-commit run --files .github/workflows/release-publish.yml`: passed.
- Post-merge plan: re-invoke `release-publish-trigger` skill for the open
  draft `v0.1.4`; the gate "Workflow file present and functional" now
  passes and the dispatch reaches the reusable workflow.

## Risk / rollout notes

Low risk — wrapper-only change, the reusable workflow is unchanged. No
runtime behaviour shifts until an operator dispatches the workflow. Per
spec/project/release-automation/ §Pre-publish verification, an invalid
dispatch from this point still falls into validation-only failure modes,
not into accidental publishes.