### PR TITLE
fix: add workflow_dispatch trigger to release-cd cascade workflows

### DIFF
--- a/.github/workflows/release-cd-deliver-docs.yml
+++ b/.github/workflows/release-cd-deliver-docs.yml
@@ -1,6 +1,10 @@
 on:
   release:
     types: [published]
+  # Manual fallback when the `release: published` event was emitted under
+  # GITHUB_TOKEN — GitHub doesn't fire downstream workflows in that case
+  # (Known Platform Constraint per spec/project/workflow-health/).
+  workflow_dispatch:
 
 jobs:
   publish_docs:

--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -1,6 +1,10 @@
 on:
   release:
     types: [published]
+  # Manual fallback when the `release: published` event was emitted under
+  # GITHUB_TOKEN — GitHub doesn't fire downstream workflows in that case
+  # (Known Platform Constraint per spec/project/workflow-health/).
+  workflow_dispatch:
 
 jobs:
   refresh_presentation_branch:


### PR DESCRIPTION
## Summary

`release-cd-deliver-docs.yml` and `release-cd-refresh-master.yml` both
only listen to `release: published`. When that event is emitted by a
workflow running under `GITHUB_TOKEN` — which is exactly what
`release-publish.yml` does — GitHub deterministically suppresses
downstream workflow runs (Known Platform Constraint per
`spec/project/workflow-health/`). The result: `v0.1.4` published
successfully today, but neither the docs deploy to `gh-pages` nor the
main-branch refresh ran, and the rendered site at
https://nolte.github.io/taskfiles is still on the January-2024 build.

## Changes

- Add `workflow_dispatch:` to `.github/workflows/release-cd-deliver-docs.yml`.
- Add `workflow_dispatch:` to `.github/workflows/release-cd-refresh-master.yml`.
- Inline a short comment on each pointing at the Known-Platform-Constraint
  rationale, mirroring the comment added to `release-drafter.yml` in #24.

The `release: published` trigger stays the default path; the manual
dispatch is the documented fallback for the GITHUB_TOKEN cascade case.

## Linked issues

Refs spec/project/workflow-health/
Refs spec/project/release-automation/

## Testing

- `pre-commit run --files <both files>`: passed.
- Post-merge plan:
  1. `gh workflow run release-cd-deliver-docs.yml --ref develop` →
     gh-pages picks up the Diátaxis + EN/DE i18n site (#23) and the
     per-module pages (#21);
  2. `gh workflow run release-cd-refresh-master.yml --ref develop` →
     `main` fast-forwards to the `v0.1.4` tag.

## Risk / rollout notes

Low risk — additive trigger, no runtime behaviour shift until an
operator dispatches. Both workflows already use `GITHUB_TOKEN` and their
existing permissions; nothing widens. The long-term fix remains the
portfolio-level App-token remediation in `nolte/gh-plumbing` that lifts
the cascade constraint outright; this PR is the local mitigation pattern
the same as #24.