### PR TITLE
chore(workflows): bump gh-plumbing reusables to v1.1.19

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   automerge:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.19
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -3,16 +3,16 @@ on:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.19
 
   security:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.19
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
 
   chain-bench:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.19
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-cd-deliver-docs.yml
+++ b/.github/workflows/release-cd-deliver-docs.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish_docs:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@v1.1.19
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   refresh_presentation_branch:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@v1.1.19
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   update_release_draft:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@v1.1.19
     permissions:
       # write permission is required to create a github release
       contents: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   publish_release:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.19
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   spelling:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@v1.1.18
+    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@v1.1.19


### PR DESCRIPTION
## Summary

Bumps every `nolte/gh-plumbing/.github/workflows/*@v1.1.18` pin to `@v1.1.19`. The caller-side config for `automerge.yaml` and `release-publish.yml` was already wired for the v1.1.19 portfolio-app token cascade (`app-id` + `secrets.app-private-key`), but the pin was lagging — causing `startup_failure` because the v1.1.18 reusable doesn't accept those inputs.

## Changes

- Sed-replace `@v1.1.18` → `@v1.1.19` across every workflow file under `.github/workflows/` (no other diffs).

## Linked issues

None

## Testing

- `git diff --stat` confirms only intended pin lines changed.
- This PR uses native `gh pr merge --squash --auto` because `pascalgn/automerge-action` is broken on this repo until the new pin lands.

## Risk / rollout notes

Mechanical pin bump. The caller-side config is unchanged. Once merged, the repo's automerge.yaml and release-publish.yml workflows can again resolve their reusable callers, restoring the portfolio-app cascade.
