### PR TITLE
feat(portfolio): add portfolio manifest (reusable Taskfile collection)

### DIFF
--- a/project/portfolio.yml
+++ b/project/portfolio.yml
@@ -1,0 +1,21 @@
+# Portfolio manifest for nolte/taskfiles.
+# Schema: spec/portfolio/portfolio-management/ §Capability inventory per repository
+# Audience references resolve against AUDIENCES.md at the repo root.
+
+capabilities:
+  - name: reusable-taskfile-collection
+    description: >-
+      A collection of remotely-includable Taskfiles (src/taskfile-include-*.yaml
+      for mkdocs, pre-commit, kind, and k8s) that downstream nolte/* projects
+      include via the Task includes: mechanism to get consistent task targets
+      without copying Taskfile logic into each repository.
+    audience:
+      - Taskfile-consumer project
+      - Consumer-side developer running tasks locally
+      - Consumer-side CI/CD pipeline
+    status: active
+    rationale: >-
+      taskfiles is the single portfolio source of reusable Task includes;
+      consolidating them here keeps task targets consistent across consumers and
+      removes the per-repo Taskfile duplication the 2026-06-02 portfolio audit
+      flagged.


### PR DESCRIPTION
## Summary

Adds the first `project/portfolio.yml` to `nolte/taskfiles`, resolving Warning **W2** (and part of **W3**) from the 2026-06-02 portfolio audit (nolte/claude-shared `.audits/portfolio/2026-06-02.md`, tracked in nolte/claude-shared#262). taskfiles provided a portfolio-wide reusable-Taskfile capability consumed across repos but declared no manifest.

## Changes

Declares one capability grounded in what the repo ships and mapped to existing `AUDIENCES.md` entries:

- **reusable-taskfile-collection** — the `src/taskfile-include-*.yaml` includes (mkdocs, pre-commit, kind, k8s) that downstream nolte/* projects include via Task's `includes:` mechanism. Audience: Taskfile-consumer project, consumer-side developer, consumer-side CI/CD pipeline. `status: active`.

## Linked issues

Refs nolte/claude-shared#262

## Testing

- `project/portfolio.yml` validated locally: capability carries all five required fields; folded-scalar description reconstructs verbatim.

## Risk / rollout notes

Low — additive manifest metadata; no code change. A follow-up `mission-define` is still tracked under claude-shared#262 (taskfiles has no `project/mission.md` yet).